### PR TITLE
Add optimized Roberts Cross implementations

### DIFF
--- a/include/algo.hpp
+++ b/include/algo.hpp
@@ -19,3 +19,9 @@ void prewitt_x_parallel_vec_wrap(const Mat& src, Mat& dst);
 void prewitt_x_parallel_vec_wrap2(const Mat& src, Mat& dst);
 
 void roberts_reference(const cv::Mat& src, cv::Mat& dst);
+
+void roberts_parallel(const cv::Mat& src, cv::Mat& dst);
+
+void roberts_parallel_vec(const cv::Mat& src, cv::Mat& dst);
+
+void roberts_parallel_vec_inplace(const cv::Mat& src, cv::Mat& dst);

--- a/perf/perf_roberts.cpp
+++ b/perf/perf_roberts.cpp
@@ -1,0 +1,47 @@
+#include <opencv2/ts.hpp>
+
+#include "algo.hpp"
+
+PERF_TEST(Roberts, ref)
+{
+    cv::Mat src(1080, 1920, CV_8UC1), dst;
+
+    PERF_SAMPLE_BEGIN()
+        roberts_reference(src, dst);
+    PERF_SAMPLE_END()
+
+    SANITY_CHECK_NOTHING();
+}
+
+PERF_TEST(Roberts, parallel)
+{
+    cv::Mat src(1080, 1920, CV_8UC1), dst;
+
+    PERF_SAMPLE_BEGIN()
+        roberts_parallel(src, dst);
+    PERF_SAMPLE_END()
+
+    SANITY_CHECK_NOTHING();
+}
+
+PERF_TEST(Roberts, parallel_vec)
+{
+    cv::Mat src(1080, 1920, CV_8UC1), dst;
+
+    PERF_SAMPLE_BEGIN()
+        roberts_parallel_vec(src, dst);
+    PERF_SAMPLE_END()
+
+    SANITY_CHECK_NOTHING();
+}
+
+PERF_TEST(Roberts, parallel_vec_nocopy)
+{
+    cv::Mat src(1080, 1920, CV_8UC1), dst;
+
+    PERF_SAMPLE_BEGIN()
+        roberts_parallel_vec_inplace(src, dst);
+    PERF_SAMPLE_END()
+
+    SANITY_CHECK_NOTHING();
+}

--- a/src/roberts.cpp
+++ b/src/roberts.cpp
@@ -12,3 +12,87 @@ void roberts_reference(const cv::Mat& src, cv::Mat& dst) {
             dst.at<uint16_t>(y, x) = dx * dx + dy * dy;
         }
 }
+
+void roberts_parallel(const cv::Mat& src, cv::Mat& dst) {
+    CV_Assert(src.type() == CV_8UC1);
+    Mat bsrc;
+    copyMakeBorder(src, bsrc, 1, 1, 1, 1, BORDER_REPLICATE);
+    dst.create(src.size(), CV_16SC1);
+    parallel_for_(Range(0, src.rows), [&](const Range& range) {
+        for (int y = range.start; y < range.end; ++y)
+            for (int x = 0; x < dst.cols; ++x) {
+                int dx = bsrc.at<uchar>(y, x) - bsrc.at<uchar>(y + 1, x + 1);
+                int dy = bsrc.at<uchar>(y, x + 1) - bsrc.at<uchar>(y + 1, x);
+                dst.at<uint16_t>(y, x) = dx * dx + dy * dy;
+            }
+    });
+}
+
+#include <opencv2/core/hal/intrin.hpp>
+
+void roberts_parallel_vec(const Mat& src, Mat& dst) {
+    Mat bsrc(src.size(), CV_8U);
+    copyMakeBorder(src, bsrc, 1, 1, 1, 1, BORDER_REPLICATE);
+    dst.create(src.size(), CV_16SC1);
+    parallel_for_(Range(0, src.rows), [&](const Range& range) {
+        for (int y = range.start; y < range.end; ++y) {
+            const uint8_t* psrc0 = bsrc.ptr(y);
+            const uint8_t* psrc1 = bsrc.ptr(y + 1);
+            uint16_t* pdst = dst.ptr<uint16_t>(y);
+            int x = 0;
+            for (; x <= dst.cols - v_int16::nlanes; x += v_int16::nlanes) {
+                v_int16 dx = v_reinterpret_as_s16(vx_load_expand(psrc0 + x)) - v_reinterpret_as_s16(vx_load_expand(psrc1 + x + 1));
+                v_int16 dy = v_reinterpret_as_s16(vx_load_expand(psrc0 + x + 1)) - v_reinterpret_as_s16(vx_load_expand(psrc1 + x));
+                v_uint16 dx2 = v_reinterpret_as_u16(v_mul_wrap(dx, dx));
+                v_uint16 dy2 = v_reinterpret_as_u16(v_mul_wrap(dy, dy));
+                v_uint16 res = v_add_wrap(dx2, dy2);
+                v_store(pdst + x, res);
+            }
+            for (; x < dst.cols; ++x) {
+                int dx = psrc0[x] - psrc1[x + 1];
+                int dy = psrc0[x + 1] - psrc1[x];
+                pdst[x] = dx * dx + dy * dy;
+            }
+        }
+    });
+}
+
+void roberts_parallel_vec_inplace(const Mat& src, Mat& dst) {
+    dst.create(src.size(), CV_16SC1);
+    parallel_for_(Range(1, src.rows), [&](const Range& range) {
+        for (int y = range.start; y < range.end; ++y) {
+            const uint8_t* psrc0 = src.ptr(y - 1);
+            const uint8_t* psrc1 = src.ptr(y);
+            uint16_t* pdst = dst.ptr<uint16_t>(y);
+            int x = 1;
+            for (; x <= dst.cols - v_int16::nlanes; x += v_int16::nlanes) {
+                v_int16 dx = v_reinterpret_as_s16(vx_load_expand(psrc0 + x - 1)) - v_reinterpret_as_s16(vx_load_expand(psrc1 + x));
+                v_int16 dy = v_reinterpret_as_s16(vx_load_expand(psrc0 + x)) - v_reinterpret_as_s16(vx_load_expand(psrc1 + x - 1));
+                v_uint16 dx2 = v_reinterpret_as_u16(v_mul_wrap(dx, dx));
+                v_uint16 dy2 = v_reinterpret_as_u16(v_mul_wrap(dy, dy));
+                v_uint16 res = v_add_wrap(dx2, dy2);
+                v_store(pdst + x, res);
+            }
+            for (; x < dst.cols; ++x) {
+                int dx = psrc0[x - 1] - psrc1[x];
+                int dy = psrc0[x] - psrc1[x - 1];
+                pdst[x] = dx * dx + dy * dy;
+            }
+        }
+    });
+
+    // First row
+    dst.at<uint16_t>(0, 0) = 0;
+    for (int x = 1; x < dst.cols; ++x) {
+        int dx = src.at<uchar>(0, x - 1) - src.at<uchar>(0, x);
+        int dy = src.at<uchar>(0, x) - src.at<uchar>(0, x - 1);
+        dst.at<uint16_t>(0, x) = dx * dx + dy * dy;
+    }
+
+    // First column
+    for (int y = 1; y < dst.rows; ++y) {
+        int dx = src.at<uchar>(y - 1, 0) - src.at<uchar>(y, 0);
+        int dy = src.at<uchar>(y, 0) - src.at<uchar>(y - 1, 0);
+        dst.at<uint16_t>(y, 0) = dx * dx + dy * dy;
+    }
+}

--- a/test/test_roberts.cpp
+++ b/test/test_roberts.cpp
@@ -1,0 +1,40 @@
+#include <opencv2/ts.hpp>
+
+#include "algo.hpp"
+
+typedef testing::TestWithParam<Size> Roberts;
+
+TEST_P(Roberts, parallel)
+{
+    cv::Mat src(GetParam(), CV_8UC1), ref, dst;
+    randu(src, 0, 255);
+
+    roberts_reference(src, ref);
+    roberts_parallel(src, dst);
+
+    EXPECT_EQ(countNonZero(ref != dst), 0);
+}
+
+TEST_P(Roberts, parallel_vec)
+{
+    cv::Mat src(GetParam(), CV_8UC1), ref, dst;
+    randu(src, 0, 255);
+
+    roberts_reference(src, ref);
+    roberts_parallel_vec(src, dst);
+
+    EXPECT_EQ(countNonZero(ref != dst), 0);
+}
+
+TEST_P(Roberts, parallel_vec_nocopy)
+{
+    cv::Mat src(GetParam(), CV_8UC1), ref, dst;
+    randu(src, 0, 255);
+
+    roberts_reference(src, ref);
+    roberts_parallel_vec_inplace(src, dst);
+
+    EXPECT_EQ(countNonZero(ref != dst), 0);
+}
+
+INSTANTIATE_TEST_CASE_P(/**/, Roberts, testing::Values(TYPICAL_MAT_SIZES));


### PR DESCRIPTION
Following optimizations were implemented:

- Thread-parallel, with `cv::parallel_for_()`
- Data-parallel (vectorized), with OpenCV intrinsics wrappers
- Data-parallel (vectorized), with OpenCV intrinsics wrappers, in-place

Note that the regression test is filling the input with the entire INT8 range, not cheating by `urand(0, 127)` to avoid overflow ;-) 

```
[----------] 4 tests from Roberts
[ RUN      ] Roberts.ref
[ PERFSTAT ]    (samples=100   mean=0.63   median=0.58   min=0.50   stddev=0.11 (17.8%))
[       OK ] Roberts.ref (71 ms)
[ RUN      ] Roberts.parallel
[ PERFSTAT ]    (samples=100   mean=0.47   median=0.44   min=0.40   stddev=0.08 (16.5%))
[       OK ] Roberts.parallel (54 ms)
[ RUN      ] Roberts.parallel_vec
[ PERFSTAT ]    (samples=100   mean=0.54   median=0.49   min=0.45   stddev=0.09 (16.7%))
[       OK ] Roberts.parallel_vec (60 ms)
[ RUN      ] Roberts.parallel_vec_nocopy
[ PERFSTAT ]    (samples=100   mean=0.10   median=0.10   min=0.09   stddev=0.01 (8.1%))
[       OK ] Roberts.parallel_vec_nocopy (11 ms)
[----------] 4 tests from Roberts (197 ms total)
```